### PR TITLE
Add Zero division exception and test

### DIFF
--- a/pythonmaths/arithmetic.py
+++ b/pythonmaths/arithmetic.py
@@ -52,7 +52,12 @@ def divide(x: int | float, y: int | float) -> float:
     >>> arithmetic.divide(5, 2)
         2.5
     """
-    return x / y
+    try:
+        return x / y
+    except ZeroDivisionError as e:
+        raise ZeroDivisionError(
+        "You can not divide by 0, please choose another value for 'y'."
+        ) from e
 
 
 def multiply(x: int | float, y: int | float) -> float:

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -64,3 +64,7 @@ def test_multiply(x: int | float, y: int | float, expected: int | float) -> None
 def test_divide(x: int | float, y: int | float, expected: int | float) -> None:
     """Test the divide function."""
     assert arithmetic.divide(x, y) == pytest.approx(expected)
+def test_divide_zero_division_exception() -> None:
+    """Test that a ZeroDivisionError is raised by the divide() function."""
+    with pytest.raises(ZeroDivisionError):
+        arithmetic.divide(2, 0)


### PR DESCRIPTION
Closes #1:
This PR adds a zero division exception in `pythonmaths/arithmetic.py` to indicate to the user that they need to select a different denominator for division. It also adds a test to check that the exception is working correctly.